### PR TITLE
Add scripts to start/stop docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Crafter CMS Docker Compose
 
-This project provides Docker compose files that allow you to run Docker containers for the following Crafter CMS 
+This project provides Docker compose files that allow you to run Docker containers for the following Crafter CMS
 environments:
 
 * Authoring
@@ -15,38 +15,58 @@ files for production and use these as a reference.
 1. Install Docker (https://docs.docker.com/install/)
 2. Install Docker Compose (https://docs.docker.com/compose/install/)
 
-**For Windows and Mac, we recommend you give Docker Desktop at least 8GB of RAM and 4 CPUs. To do this, go to Docker 
+**For Windows and Mac, we recommend you give Docker Desktop at least 8GB of RAM and 4 CPUs. To do this, go to Docker
 Desktop's Preferences > Resources > Advanced, and then change the resource limits.**
 
 ![Docker Advanced Settings](docker-advanced-settings.png)
 
 # Mount the Authoring site repositories directory to a host directory
 
-Sometimes you'll need to have the Authoring site repositories available in the host filesystem, specially if 
+Sometimes you'll need to have the Authoring site repositories available in the host filesystem, specially if
 you want to update the files from your IDE. To make the sites available, follow these steps:
 
 **NOTE:** This will only work on an Authoring with no existing data. To clear the current data, run the same
 command you've been using to start up the environment, but replace the `up` part for `down -v`.
 
-0. Make sure the drive with the directory that will contain the sites is a shared drive (check Docker Desktop's 
+0. Make sure the drive with the directory that will contain the sites is a shared drive (check Docker Desktop's
 Preferences > Resources > File Sharing)
 1. `cd authoring`
-2. Open the `docker-compose.yaml` in an editor and add the following volume to both the `tomcat` and the `deployer` 
-service (assume `C` is the shared drive, and replace the `/host/path/to/sites` for the actual host path): 
+2. Open the `docker-compose.yaml` in an editor and add the following volume to both the `tomcat` and the `deployer`
+service (assume `C` is the shared drive, and replace the `/host/path/to/sites` for the actual host path):
 `- c:/host/path/to/sites:/opt/crafter/data/repos/sites`
 3. Once you have started the Authoring environment, by following the steps below, go to the Authoring browser URL and create a site. You should be able to see the files in your host directory!
 
 # Start Authoring Environment
 
+## Start with script
+
+```
+$ cd scripts
+$ ./start authoring [--enterprise, -e]
+$ ./logs authoring # to output log
+```
+
+## Start manual
 1. `cd authoring`.
-2. `docker-compose up` to run the containers in the foreground or `docker-compose up -d` to run them detached in the 
+2. `docker-compose up` to run the containers in the foreground or `docker-compose up -d` to run them detached in the
 background (and `docker-compose logs -f` to tail the logs).
 
 # Start Delivery Environment
 
+## Start with script
+
+```
+$ cd scripts
+$ ./start authoring [--enterprise, -e]
+$ ./start delivery [--enterprise, -e]
+$ ./logs delivery # to output log
+```
+
+## Start manual
+
 1. Start the Authoring environment.
 2. `cd delivery`.
-3. `docker-compose up` to run the containers in the foreground or `docker-compose up -d` to run them detached in the 
+3. `docker-compose up` to run the containers in the foreground or `docker-compose up -d` to run them detached in the
 background (and `docker-compose logs -f` to tail the logs).
 
 ## Create a Delivery Site
@@ -66,23 +86,32 @@ background (and `docker-compose logs -f` to tail the logs).
 *Step 1: Create the site in the authoring environment* to *Step 3: Create the AWS Target in Authoring Crafter Deployer*.
 Don't do *Step 4: Configure the Delivery Crafter Engine for Serverless Mode*.
 3. `cd serverless/s3/delivery`.
-4. Specify in the `serverless/s3/delivery/.env` file the required environment variables: 
+4. Specify in the `serverless/s3/delivery/.env` file the required environment variables:
    - **ES_URL:** The AWS Elasticsearch endpoint (or any other valid Elasticsearch URL).
-   - **crafter.engine.site.default.rootFolder.path:** The URL to the S3 bucket with the sites. Format is 
+   - **crafter.engine.site.default.rootFolder.path:** The URL to the S3 bucket with the sites. Format is
      `s3://<BUCKET_NAME>/<SITES_ROOT>/{siteName}`. Example: `s3://serverless/sites/{siteName}`.
    - **crafter.engine.s3.region:** The AWS region of the S3 bucket.
    - **crafter.engine.s3.accessKey:** The AWS access key.
    - **crafter.engine.s3.secretKey:** The AWS secret key.
-5. `docker-compose up` to run the containers in the foreground or `docker-compose up -d` to run them detached in the 
+5. `docker-compose up` to run the containers in the foreground or `docker-compose up -d` to run them detached in the
 background (and `docker-compose logs -f` to tail the logs).
 
 # Stop an Environment
+
+## Stop with script
+
+```
+$ cd scripts
+$ ./stop <ENVIRONMENT (authoring, delivery)> [--delete-volumes, -v]
+```
+
+## Stop manual
 
 - If `docker-compose` is running in the foreground, `CTRL+C` should stop the containers.
 - If `docker-compose` is running detached, then call `docker-compose stop` or `docker-compose down`. The difference
 between the two is that `down` will also remove the containers and networks created.
 
-You can also run `docker-compose down -v` to delete the volumes, which contain the data and logs, when you want to 
+You can also run `docker-compose down -v` to delete the volumes, which contain the data and logs, when you want to
 start with a fresh install.
 
 # Backup Authoring/Delivery
@@ -90,7 +119,7 @@ start with a fresh install.
 1. `cd scripts`
 2. `./backup <ENVIRONMENT> <BACKUP_FOLDER>` (remember to replace `<ENVIRONMENT>` (authoring or delivery) and `<BACKUP_FOLDER>`). E.g. `./backup authoring C:/Users/jdoe/Documents/Backups`
 
-**NOTE:** In Windows, make sure `/host/path/to/backups` points to a path in a shared drive (check Docker Desktop's 
+**NOTE:** In Windows, make sure `/host/path/to/backups` points to a path in a shared drive (check Docker Desktop's
 Settings > Shared Drives)
 
 # Restore Authoring/Delivery
@@ -98,7 +127,7 @@ Settings > Shared Drives)
 1. `cd scripts`
 2. `./restore <ENVIRONMENT> <BACKUP_FOLDER> <BACKUP_FILE>` (remember to replace `<ENVIRONMENT>` (authoring or delivery), `<BACKUP_FOLDER>` and `<BACKUP_FILE>`). E.g. `./restore authoring C:/Users/jdoe/Documents/Backups crafter-authoring-backup.2019-03-28-00-58-33.zip`
 
-**NOTE:** In Windows and Mac, make sure `/host/path/to/backups` points to a path in a shared drive (check Docker 
+**NOTE:** In Windows and Mac, make sure `/host/path/to/backups` points to a path in a shared drive (check Docker
 Desktop's Settings > Shared Drives)
 
 # Run a command inside a running container
@@ -120,13 +149,13 @@ For each authoring and delivery compose files there are 3 services:
 
 For serverless S3 delivery there's only one service: `tomcat`.
 
-Please **ALWAYS** use `gosu crafter` with `docker-compose exec`. This ensures that all the commands are run as the 
+Please **ALWAYS** use `gosu crafter` with `docker-compose exec`. This ensures that all the commands are run as the
 `crafter` user and that all new files and directories created belong to `crafter` (`gosu` is basically a version
 of `sudo` that works better on Docker).
 
 # Open a shell to a container
 
-Sometimes you'll need to get a shell to a container for debugging purposes or for executing Git operations. To do this, 
+Sometimes you'll need to get a shell to a container for debugging purposes or for executing Git operations. To do this,
 run the following command:
 
 `docker-compose exec <SERVICE_NAME> gosu crafter bash`
@@ -139,10 +168,10 @@ To use the Enterprise Edition instead of the Community Edition follow these step
 
 1. `cd ENVIRONMENT`
 2. Copy your Crafter license under `./license/crafter.lic`
-3. `docker-compose -f docker-compose.yml -f docker-compose.enterprise.yml up` or 
+3. `docker-compose -f docker-compose.yml -f docker-compose.enterprise.yml up` or
 `docker-compose -f docker-compose.yml -f docker-compose.enterprise.yml up -d`
 
 ## Enterprise Edition Compatible With Solr
 
-Follow the previous steps, but in step 3, replace `docker-compose.enterprise.yml` with `docker-compose.solr.yml` 
+Follow the previous steps, but in step 3, replace `docker-compose.enterprise.yml` with `docker-compose.solr.yml`
 (e.g. `docker-compose -f docker-compose.yml -f docker-compose.solr.yml up`)

--- a/scripts/logs.bat
+++ b/scripts/logs.bat
@@ -1,0 +1,42 @@
+@echo off
+
+REM Copyright (C) 2007-2021 Crafter Software Corporation. All Rights Reserved.
+
+REM This program is free software: you can redistribute it and/or modify
+REM it under the terms of the GNU General Public License as published by
+REM the Free Software Foundation, either version 3 of the License, or
+REM (at your option) any later version.
+
+REM This program is distributed in the hope that it will be useful,
+REM but WITHOUT ANY WARRANTY; without even the implied warranty of
+REM MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+REM GNU General Public License for more details.
+
+REM You should have received a copy of the GNU General Public License
+REM along with this program.  If not, see <http://www.gnu.org/license
+
+set ENVIRONMENT=%1
+
+if "%ENVIRONMENT%"=="authoring" (
+  goto output_logs
+)
+
+if "%ENVIRONMENT%"=="delivery" (
+  goto output_logs
+)
+
+goto print_help
+
+:output_logs
+pushd ..\%ENVIRONMENT%
+docker-compose logs -f
+popd
+goto end
+
+:print_help
+echo "Usage:"
+echo "log.bat <ENVIRONMENT (authoring, delivery)>"
+echo "-h, --help: Prints help"
+goto end
+
+:end

--- a/scripts/logs.sh
+++ b/scripts/logs.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2007-2021 Crafter Software Corporation. All Rights Reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/license
+
+ENVIRONMENT=$1
+
+print_help()
+{
+  echo "Usage:"
+  echo "./logs.sh <ENVIRONMENT (authoring, delivery)>"
+  printf '\t%s\n' "-h, --help: Prints help"
+}
+
+if [[ "$ENVIRONMENT" != "authoring" && "$ENVIRONMENT" != "delivery" ]]; then
+  print_help
+  exit 1
+fi
+
+pushd ../$ENVIRONMENT
+docker-compose logs -f
+popd

--- a/scripts/start.bat
+++ b/scripts/start.bat
@@ -1,0 +1,55 @@
+@echo off
+
+REM Copyright (C) 2007-2021 Crafter Software Corporation. All Rights Reserved.
+
+REM This program is free software: you can redistribute it and/or modify
+REM it under the terms of the GNU General Public License as published by
+REM the Free Software Foundation, either version 3 of the License, or
+REM (at your option) any later version.
+
+REM This program is distributed in the hope that it will be useful,
+REM but WITHOUT ANY WARRANTY; without even the implied warranty of
+REM MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+REM GNU General Public License for more details.
+
+REM You should have received a copy of the GNU General Public License
+REM along with this program.  If not, see <http://www.gnu.org/license
+
+set ENVIRONMENT=%1
+set ARG_ENTERPRISE=%2
+
+if "%ENVIRONMENT%"=="authoring" (
+  goto start_compose
+)
+
+if "%ENVIRONMENT%"=="delivery" (
+  goto start_compose
+)
+
+goto print_help
+
+:start_compose
+if "%ARG_ENTERPRISE%" == "--enterprise" (
+    goto start_compose_enterprise
+)
+if "%ARG_ENTERPRISE%" == "-e" (
+    goto start_compose_enterprise
+)
+pushd ..\%ENVIRONMENT%
+docker-compose up -d
+popd
+goto end
+
+:start_compose_enterprise
+pushd ..\%ENVIRONMENT%
+docker-compose -f docker-compose.yml -f docker-compose.enterprise.yml up -d
+popd
+goto end
+
+:print_help
+echo "Usage:"
+echo "start.bat <ENVIRONMENT (authoring, delivery)> [--enterprise, -e]"
+echo "-h, --help: Prints help"
+goto end
+
+:end

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2007-2021 Crafter Software Corporation. All Rights Reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/license
+
+ENVIRONMENT=$1
+_arg_enterprise="false"
+
+die()
+{
+  local _ret="${2:-1}"
+  test "${_PRINT_HELP:-no}" = yes && print_help >&2
+  echo "$1" >&2
+  exit "${_ret}"
+}
+
+print_help()
+{
+  echo "Usage:"
+  echo "./start.sh <ENVIRONMENT (authoring, delivery)> [--enterprise, -e]"
+  printf '\t%s\n' "-h, --help: Prints help"
+}
+
+parse_commandline()
+{
+  while test $# -gt 0
+  do
+    _key="$1"
+    case "$_key" in
+      -e|--enterprise)
+        _arg_enterprise="true"
+        ;;
+      -h|--help)
+        print_help
+        exit 0
+        ;;
+      -h*)
+        print_help
+        exit 0
+        ;;
+      *)
+        echo "$_key"
+        _PRINT_HELP=yes die "FATAL ERROR: Got an unexpected argument '$1'" 1
+        ;;
+    esac
+    shift
+  done
+}
+
+if [[ "$ENVIRONMENT" != "authoring" && "$ENVIRONMENT" != "delivery" ]]; then
+  print_help
+  exit 1
+fi
+
+parse_commandline "${@:2}"
+
+command="docker-compose up -d"
+
+if [[ $_arg_enterprise == "true" ]]
+then
+  command="docker-compose -f docker-compose.yml -f docker-compose.enterprise.yml up -d"
+fi
+
+pushd ../$ENVIRONMENT
+eval $command
+popd

--- a/scripts/stop.bat
+++ b/scripts/stop.bat
@@ -1,0 +1,71 @@
+@echo off
+
+REM Copyright (C) 2007-2021 Crafter Software Corporation. All Rights Reserved.
+
+REM This program is free software: you can redistribute it and/or modify
+REM it under the terms of the GNU General Public License as published by
+REM the Free Software Foundation, either version 3 of the License, or
+REM (at your option) any later version.
+
+REM This program is distributed in the hope that it will be useful,
+REM but WITHOUT ANY WARRANTY; without even the implied warranty of
+REM MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+REM GNU General Public License for more details.
+
+REM You should have received a copy of the GNU General Public License
+REM along with this program.  If not, see <http://www.gnu.org/license
+
+set ENVIRONMENT=%1
+set ARG_DELETE_VOLUMES=%2
+
+if "%ENVIRONMENT%"=="authoring" (
+  goto stop_compose
+)
+
+if "%ENVIRONMENT%"=="delivery" (
+  goto stop_compose
+)
+
+goto print_help
+
+:stop_compose
+if "%ARG_DELETE_VOLUMES%" == "--delete-volumes" (
+    goto stop_compose_delete_volumes_confirm
+)
+if "%ARG_DELETE_VOLUMES%" == "-v" (
+    goto stop_compose_delete_volumes_confirm
+)
+pushd ..\%ENVIRONMENT%
+docker-compose down
+popd
+goto end
+
+:stop_compose_delete_volumes_confirm
+set CONFIRM=
+echo "WARNING! This will remove named volumes declared in the volumes section of the Compose file and anonymous volumes attached to containers."
+set /P CONFIRM="Are you sure to process this? [Y/n]?"
+if /I "%CONFIRM%" == "y" (
+    goto stop_compose_delete_volumes
+)
+if /I "%CONFIRM%" == "yes" (
+    goto stop_compose_delete_volumes
+)
+if "%CONFIRM%" == "" (
+    goto stop_compose_delete_volumes
+)
+echo "Aborting..."
+goto end
+
+:stop_compose_delete_volumes
+pushd ..\%ENVIRONMENT%
+docker-compose down -v
+popd
+goto end
+
+:print_help
+echo "Usage:"
+echo "stop.bat <ENVIRONMENT (authoring, delivery)> [--delete-volumes, -v]"
+echo "-h, --help: Prints help"
+goto end
+
+:end

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2007-2021 Crafter Software Corporation. All Rights Reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/license
+
+ENVIRONMENT=$1
+_arg_delete_volumes="false"
+
+die()
+{
+  local _ret="${2:-1}"
+  test "${_PRINT_HELP:-no}" = yes && print_help >&2
+  echo "$1" >&2
+  exit "${_ret}"
+}
+
+print_help()
+{
+  echo "Usage:"
+  echo "./stop.sh <ENVIRONMENT (authoring, delivery)> [--delete-volumes, -v]"
+  printf '\t%s\n' "-h, --help: Prints help"
+}
+
+parse_commandline()
+{
+  while test $# -gt 0
+  do
+    _key="$1"
+    case "$_key" in
+      -v|--delete-volumes)
+        _arg_delete_volumes="true"
+        ;;
+      -h|--help)
+        print_help
+        exit 0
+        ;;
+      -h*)
+        print_help
+        exit 0
+        ;;
+      *)
+        echo "$_key"
+        _PRINT_HELP=yes die "FATAL ERROR: Got an unexpected argument '$1'" 1
+        ;;
+    esac
+    shift
+  done
+}
+
+if [[ "$ENVIRONMENT" != "authoring" && "$ENVIRONMENT" != "delivery" ]]; then
+  print_help
+  exit 1
+fi
+
+parse_commandline "${@:2}"
+
+command="docker-compose down"
+
+if [[ $_arg_delete_volumes == "true" ]]
+then
+  echo "WARNING! This will remove named volumes declared in the volumes section of the Compose file and anonymous volumes attached to containers."
+  read -r -p "Are you sure to process this? [Y/n] " response
+  if [[ ! "${response,,}" =~ ^(yes|y| ) ]] && [[ ! -z $response ]]; then
+    echo "Aborting..."
+    exit 1
+  else
+    command="$command -v"
+  fi
+fi
+
+pushd ../$ENVIRONMENT
+eval $command
+popd


### PR DESCRIPTION
Ticket: https://github.com/craftercms/craftercms/issues/4743
For `stop` script: I think we don't need to add the option `--enterprise` since docker-compose is 

> Stops containers and removes containers, networks, volumes, and images created by up.

https://docs.docker.com/compose/reference/down/