### PR TITLE
Use SOLR_JAVA_MEM and SOLR_JAVA_STACK_SIZE to resolve duplicated JVM heap parameters

### DIFF
--- a/authoring/docker-compose.solr.yml
+++ b/authoring/docker-compose.solr.yml
@@ -19,7 +19,7 @@ services:
     ports:
       - 8694:8983
     environment:
-      - "SOLR_JAVA_MEM=-Xmx1G"
+      - "SOLR_JAVA_MEM=-Xms1G -Xmx1G"
       - "SOLR_JAVA_STACK_SIZE=-Xss1024K"
     volumes:
       - ./solr/config/solr/configsets/crafter_configs:/opt/solr/server/solr/configsets/crafter_configs

--- a/authoring/docker-compose.solr.yml
+++ b/authoring/docker-compose.solr.yml
@@ -19,7 +19,8 @@ services:
     ports:
       - 8694:8983
     environment:
-      - "SOLR_OPTS=-Xss1024K -Xmx1G"
+      - "SOLR_JAVA_MEM=-Xmx1G"
+      - "SOLR_JAVA_STACK_SIZE=-Xss1024K"
     volumes:
       - ./solr/config/solr/configsets/crafter_configs:/opt/solr/server/solr/configsets/crafter_configs
       - ./solr/config/solr/solr.xml:/opt/solr/server/solr/solr.xml

--- a/delivery/docker-compose.solr.yml
+++ b/delivery/docker-compose.solr.yml
@@ -19,7 +19,7 @@ services:
     ports:
       - 8695:8983
     environment:
-      - "SOLR_JAVA_MEM=-Xmx1G"
+      - "SOLR_JAVA_MEM=-Xms1G -Xmx1G"
       - "SOLR_JAVA_STACK_SIZE=-Xss1024K"
     volumes:
       - ./solr/config/solr/configsets/crafter_configs:/opt/solr/server/solr/configsets/crafter_configs

--- a/delivery/docker-compose.solr.yml
+++ b/delivery/docker-compose.solr.yml
@@ -19,7 +19,8 @@ services:
     ports:
       - 8695:8983
     environment:
-      - "SOLR_OPTS=-Xss1024K -Xmx1G"
+      - "SOLR_JAVA_MEM=-Xmx1G"
+      - "SOLR_JAVA_STACK_SIZE=-Xss1024K"
     volumes:
       - ./solr/config/solr/configsets/crafter_configs:/opt/solr/server/solr/configsets/crafter_configs
       - ./solr/config/solr/solr.xml:/opt/solr/server/solr/solr.xml


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/5026

@avasquez614 Similar duplicated params issue for docker-compose.

In `solr/bin/solr` script:

```
JAVA_MEM_OPTS=()
if [ -z "$SOLR_HEAP" ] && [ -n "$SOLR_JAVA_MEM" ]; then
  JAVA_MEM_OPTS=($SOLR_JAVA_MEM)
else
  SOLR_HEAP="${SOLR_HEAP:-512m}"
  JAVA_MEM_OPTS=("-Xms$SOLR_HEAP" "-Xmx$SOLR_HEAP")
fi

# Pick default for Java thread stack size, and then add to SOLR_OPTS
if [ -z ${SOLR_JAVA_STACK_SIZE+x} ]; then
  SOLR_JAVA_STACK_SIZE='-Xss256k'
fi
SOLR_OPTS+=($SOLR_JAVA_STACK_SIZE)
```

So if we put memory heap size and stack size in `SOLR_OPTS`, they are duplicated with the default value. Example running docker-compose:

```
solr          11  7.6  0.6 5355248 213680 ?      Sl   02:47   0:09 /usr/local/openjdk-11/bin/java -server -Xms512m -Xmx512m -XX:NewRatio=3 -XX:SurvivorRatio=4 -XX:TargetSurvivorRatio=90 -XX:MaxTenuringThreshold=8 -XX:+UseConcMarkSweepGC -XX:ConcGCThreads=4 -XX:ParallelGCThreads=4 -XX:+CMSScavengeBeforeRemark -XX:PretenureSizeThreshold=64m -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=50 -XX:CMSMaxAbortablePrecleanTime=6000 -XX:+CMSParallelRemarkEnabled -XX:+ParallelRefProcEnabled -XX:-OmitStackTraceInFastThrow -Xlog:gc*:file=/opt/solr/server/logs/solr_gc.log:time,uptime:filecount=9,filesize=20M -Dsolr.log.dir=/opt/solr/server/logs -Djetty.port=8983 -DSTOP.PORT=7983 -DSTOP.KEY=solrrocks -Duser.timezone=UTC -Djetty.home=/opt/solr/server -Dsolr.solr.home=/opt/solr/server/solr -Dsolr.data.home= -Dsolr.install.dir=/opt/solr -Dsolr.default.confdir=/opt/solr/server/solr/configsets/_default/conf -Xss1024K -Xmx1G -Xss256k -Dsolr.jetty.https.port=8983 -jar start.jar --module=http
````

Noticate that we have duplicated (`-Xmx512m`, `-Xmx1G`) (`-Xss1024K`, `-Xss256k`)

Run docker-compose after the fix:

```
solr          11 22.9  0.6 5375724 211520 ?      Sl   03:05   0:09 /usr/local/openjdk-11/bin/java -server -Xmx1G -XX:NewRatio=3 -XX:SurvivorRatio=4 -XX:TargetSurvivorRatio=90 -XX:MaxTenuringThreshold=8 -XX:+UseConcMarkSweepGC -XX:ConcGCThreads=4 -XX:ParallelGCThreads=4 -XX:+CMSScavengeBeforeRemark -XX:PretenureSizeThreshold=64m -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=50 -XX:CMSMaxAbortablePrecleanTime=6000 -XX:+CMSParallelRemarkEnabled -XX:+ParallelRefProcEnabled -XX:-OmitStackTraceInFastThrow -Xlog:gc*:file=/opt/solr/server/logs/solr_gc.log:time,uptime:filecount=9,filesize=20M -Dsolr.log.dir=/opt/solr/server/logs -Djetty.port=8983 -DSTOP.PORT=7983 -DSTOP.KEY=solrrocks -Duser.timezone=UTC -Djetty.home=/opt/solr/server -Dsolr.solr.home=/opt/solr/server/solr -Dsolr.data.home= -Dsolr.install.dir=/opt/solr -Dsolr.default.confdir=/opt/solr/server/solr/configsets/_default/conf -Xss1024K -Dsolr.jetty.https.port=8983 -jar start.jar --module=http
```

There is no duplicated.