### PR TITLE
Upgrade elastichsearch to 7.15.1

### DIFF
--- a/authoring/docker-compose.yml
+++ b/authoring/docker-compose.yml
@@ -15,7 +15,7 @@
 version: '3.7'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.7.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.15.1
     ports:
       - 9201:9200
     environment:

--- a/delivery/docker-compose.yml
+++ b/delivery/docker-compose.yml
@@ -15,7 +15,7 @@
 version: '3.7'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.7.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.15.1
     ports:
       - 9202:9200
     environment:


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/5108

```
bash-4.4# curl http://localhost:9200
{
  "name" : "7dca4a94240d",
  "cluster_name" : "docker-cluster",
  "cluster_uuid" : "cEBOCuSCT3ejUiAYcjg_TQ",
  "version" : {
    "number" : "7.15.1",
    "build_flavor" : "default",
    "build_type" : "docker",
    "build_hash" : "83c34f456ae29d60e94d886e455e6a3409bba9ed",
    "build_date" : "2021-10-07T21:56:19.031608185Z",
    "build_snapshot" : false,
    "lucene_version" : "8.9.0",
    "minimum_wire_compatibility_version" : "6.8.0",
    "minimum_index_compatibility_version" : "6.0.0-beta1"
  },
  "tagline" : "You Know, for Search"
}
```