### PR TITLE
Upgrade ES to 7.16.2

### DIFF
--- a/authoring/docker-compose.yml
+++ b/authoring/docker-compose.yml
@@ -15,7 +15,7 @@
 version: '3.7'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.15.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.16.2
     ports:
       - 9201:9200
     environment:

--- a/delivery/docker-compose.yml
+++ b/delivery/docker-compose.yml
@@ -15,7 +15,7 @@
 version: '3.7'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.15.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.16.2
     ports:
       - 9202:9200
     environment:


### PR DESCRIPTION
root@f8fe0c18ec8a:/usr/share/elasticsearch# curl http://localhost:9200
{
  "name" : "f8fe0c18ec8a",
  "cluster_name" : "docker-cluster",
  "cluster_uuid" : "cEBOCuSCT3ejUiAYcjg_TQ",
  "version" : {
    "number" : "7.16.2",
    "build_flavor" : "default",
    "build_type" : "docker",
    "build_hash" : "2b937c44140b6559905130a8650c64dbd0879cfb",
    "build_date" : "2021-12-18T19:42:46.604893745Z",
    "build_snapshot" : false,
    "lucene_version" : "8.10.1",
    "minimum_wire_compatibility_version" : "6.8.0",
    "minimum_index_compatibility_version" : "6.0.0-beta1"
  },
  "tagline" : "You Know, for Search"
}
